### PR TITLE
Add help documentation

### DIFF
--- a/bin/help.config
+++ b/bin/help.config
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+printf "Install latest:\n"
+printf "  > asdf install protonge latest\n\n"

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+printf "ProtonGE:       https://github.com/GloriousEggroll/proton-ge-custom\n"
+printf "asdf-protonge:  https://github.com/augustobmoura/asdf-protonge\n"

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "Manage ProtonGE with asdf\n\n"


### PR DESCRIPTION
This adds some of the help scripts to present help documentation when running:
``` sh
asdf help protonge
```
