### PR TITLE
Update README to fix the "plugin-add" bash command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install [`asdf-vm`](https://asdf-vm.com/guide/getting-started.html) and add this
 repo as a plugin:
 
 ```bash
-asdf plugin-add protonge https://github.com/augustobmoura/asdf-protonge.git
+asdf plugin add protonge https://github.com/augustobmoura/asdf-protonge.git
 ```
 
 Optional tools:


### PR DESCRIPTION
The readme has the command listed as "asdf plugin-add ..." when the correct command is "asdf plugin add".