### PR TITLE
Fix sorting version numbers instead of alphabetical order

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,6 +8,14 @@ if ! type tac &> /dev/null; then
 	}
 fi
 
+_sort() {
+	if which gsort &> /dev/null; then
+		gsort "$@"
+	else
+		sort "$@"
+	fi
+}
+
 get_releases_page() {
 	local page="$1" args=()
 
@@ -32,5 +40,5 @@ list_all() {
 	done
 }
 
-list_all "$@" | tac | xargs
+list_all "$@" | tac | _sort -V | xargs
 


### PR DESCRIPTION
Fix #7

Just adding `sort -V` so list-all doesn't sort by alphabetical order, instead it will sort by version numbers correctly